### PR TITLE
fix: buyer pubkey in fiat sent message

### DIFF
--- a/components/FiatSentMessage.vue
+++ b/components/FiatSentMessage.vue
@@ -52,7 +52,7 @@ export default {
       return this.getOrderById(route.params.id)
     },
     buyerPubkey() {
-      return this.order?.master_seller_pubkey
+      return this.order?.master_buyer_pubkey
     },
     sellerPubkey() {
       return this.order?.master_seller_pubkey


### PR DESCRIPTION
fiat sent message component is displaying incorrect npub