### PR TITLE
Fix/trade keys generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/node": "^22.0.2",
         "@vue/test-utils": "^2.4.6",
         "auto-changelog": "^2.4.0",
+        "fake-indexeddb": "^6.0.0",
         "jsdom": "^24.1.1",
         "nuxt": "^3.12.4",
         "typescript": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^22.0.2",
     "@vue/test-utils": "^2.4.6",
     "auto-changelog": "^2.4.0",
+    "fake-indexeddb": "^6.0.0",
     "jsdom": "^24.1.1",
     "nuxt": "^3.12.4",
     "typescript": "^5.5.4",

--- a/test/unit/utils/key-manager.test.ts
+++ b/test/unit/utils/key-manager.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { KeyManager, TradeKeysDatabase } from '../../../utils/key-manager';
+
+
+describe('KeyManager', () => {
+  let keyManager: KeyManager;
+  let db: TradeKeysDatabase;
+
+  beforeEach(async () => {
+    db = new TradeKeysDatabase();
+    keyManager = new KeyManager();
+    await keyManager.init(
+      'tomato tomato tomato tomato tomato tomato tomato tomato tomato tomato tomato tomato'
+    );
+
+    await db.tradeKeys.clear();
+  });
+
+  describe('getNextAvailableKey', () => {
+    describe('without keys', () => {
+      it('returns key with index 1', async () => {
+        const key = await keyManager.getNextAvailableKey();
+        expect(key.keyIndex).toBe(1);
+      });
+    });
+
+    describe('with unassigned keys', () => {
+      beforeEach(async () => {
+        await db.tradeKeys.add({ orderId: '', keyIndex: 3, derivedKey: 'dummy', createdAt: Date.now() });
+      });
+
+      it('returns key index of the first unassigned key', async () => {
+        const key = await keyManager.getNextAvailableKey();
+        expect(key.keyIndex).toBe(3);
+      });
+    });
+
+    describe('without unassigned keys', () => {
+      beforeEach(async () => {
+        await db.tradeKeys.add({ orderId: 'some-order', keyIndex: 1, derivedKey: 'dummy', createdAt: Date.now() });
+      });
+
+      it('throws an error', async () => {
+        await expect(keyManager.getNextAvailableKey()).rejects.toThrow('No available keys in pool');
+      });
+    });
+  });
+});

--- a/test/unit/utils/nostr.test.ts
+++ b/test/unit/utils/nostr.test.ts
@@ -4,6 +4,7 @@ import { generateSecretKey, getPublicKey, nip59 } from 'nostr-tools'
 import { Nostr } from '../../../utils/nostr'
 import { SigningMode } from '../../../utils/mostro'
 import type { Action, MostroMessage } from '~/utils/mostro/types'
+import { KeyManager } from '../../../utils/key-manager'
 
 const MOSTRO_MESSAGES = {
   TAKE_SELL: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "strict": true,
     "verbatimModuleSyntax": true,
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    "typeRoots": ["./node_modules/@types", "./types"]
   }
 }

--- a/types/fake-indexeddb.d.ts
+++ b/types/fake-indexeddb.d.ts
@@ -1,0 +1,3 @@
+declare module 'fake-indexeddb/lib/FDBKeyRange' {
+  export = window.IDBKeyRange;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,5 +28,6 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json', 'html'],
     },
+    setupFiles: './vitest.setup.ts',
   },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,5 @@
+import * as fakeIndexedDB from 'fake-indexeddb';
+import FDBKeyRange from 'fake-indexeddb/lib/FDBKeyRange';
+
+globalThis.indexedDB = fakeIndexedDB.indexedDB;
+globalThis.IDBKeyRange = FDBKeyRange;


### PR DESCRIPTION
## Context
The trade keys creation was not working in the case were the trade keys db was empty. 

## What has been done
The issue was fixed in the `KeyManager` class by ensuring that the initial index is 1 in case that there are no keys (0 is reserved for the identity key

**Commit by commit**
- Fixes the issue in the `ensureKeyPool` method of the `KeyManager` class
- Tests the public method that uses the ensureKeyPool  method (because this one is private).  For this I added a dev dependency that avoids having to add a lot of mocks that make the tests less realistic. If the number os stars of this dev dependency does not convince you, I can try the other way with  manual mocks of the dexie db. 
- Adds a missing import in a test, to avoid failure when running npm run test.

### What's next?
I think it would be nice to have a github action for tests.. What do you think?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced key management functionality now provides more robust handling of key allocation and clearer error feedback when keys are unavailable.
- **Chores**
	- Upgraded development dependencies and configurations to improve testing reliability and overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->