### PR TITLE
Fix/settings page

### DIFF
--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -96,20 +96,18 @@ const toggleButtonText = computed(() => isShown.value ? 'Hide' : 'Show')
 const mostroStore = useMostroStore()
 
 const mostroInfo = computed(() => {
-  const keys = mostroStore.listMostroKeys()
-  // for now we only have a single mostro instance, so we return the first one
-  return hexToNpub(keys[0])
+  const defaultMostroKey = mostroStore.getDefaultMostroPubkey();
+  if (!defaultMostroKey)  return '';
+
+  return hexToNpub(defaultMostroKey);
 })
 
 const secret = computed(() => {
-  if (authStore?.privKey) {
-    return hexToNsec(authStore.privKey)
-  }
-  return ''
+  return authStore?.mnemonic || '';
 })
 
 const hasSecret = computed(() => {
-  return authStore.privKey !== null
+  return !!authStore.mnemonic;
 })
 
 const onCopy = () => {

--- a/stores/mostro.ts
+++ b/stores/mostro.ts
@@ -18,6 +18,16 @@ export const useMostroStore = defineStore('mostro', {
     getMostroInfo(pubkey: string):  MostroInfo | undefined {
       return this.mostrosMap[pubkey];
     },
+    getDefaultMostroPubkey(): string | undefined {
+      // for now we only have a single mostro instance, so we return the first one
+      return this.listMostroKeys()[0];
+    },
+    getDefaultMostroInfo(): MostroInfo | undefined {
+      const defaultMostroKey = this.getDefaultMostroPubkey();
+      if (!defaultMostroKey) return undefined;
+
+      return this.mostrosMap[defaultMostroKey];
+    },
     addMostroInfo(mostroInfo: MostroInfo) {
       const previousMostroInfo = this.mostrosMap[mostroInfo.mostro_pubkey];
       if (!previousMostroInfo || previousMostroInfo.created_at <= mostroInfo.created_at) {

--- a/test/unit/stores/mostro.test.ts
+++ b/test/unit/stores/mostro.test.ts
@@ -190,6 +190,110 @@ describe('useMostroStore', () => {
     });
   });
 
+  describe('getDefaultMostroPubkey', () => {
+    describe('without mostro info', () => {
+      it ('returns undefined', () => {
+        const mostroStore = useMostroStore()
+        expect(mostroStore.getDefaultMostroPubkey()).toBeUndefined()
+      });
+    });
+
+    describe('with mostro info', () => {
+      let mostroStore: ReturnType<typeof useMostroStore>;
+  
+      beforeEach(() => {
+        mostroStore = useMostroStore()
+        mostroStore.addMostroInfo({
+          mostro_pubkey: 'my-mostro-pubkey',
+          created_at: 1739627993,
+          expiration_hours: 24,
+          expiration_seconds: 900,
+          fee: 0.01,
+          hold_invoice_expiration_window: 300,
+          invoice_expiration_window: 300,
+          max_order_amount: 1000000,
+          min_order_amount: 100,
+          mostro_commit_id: 'my-mostro-commit-id',
+          mostro_version: '0.13.0'
+        });
+        mostroStore.addMostroInfo({
+          mostro_pubkey: 'another-mostro-pubkey',
+          created_at: 1739627994,
+          expiration_hours: 48,
+          expiration_seconds: 1000,
+          fee: 0.05,
+          hold_invoice_expiration_window: 500,
+          invoice_expiration_window: 500,
+          max_order_amount: 5000000,
+          min_order_amount: 500,
+          mostro_commit_id: 'another-mostro-commit-id',
+          mostro_version: '0.12.0'
+        });
+      });
+      it ('returns first key', () => {
+        expect(mostroStore.getDefaultMostroPubkey()).toEqual('my-mostro-pubkey');
+      });
+    });
+  });
+
+  describe('getDefaultMostroInfo', () => {
+    describe('without mostro info', () => {
+      it ('returns undefined', () => {
+        const mostroStore = useMostroStore()
+        expect(mostroStore.getDefaultMostroInfo()).toBeUndefined()
+      });
+    });
+
+    describe('with mostro info', () => {
+      let mostroStore: ReturnType<typeof useMostroStore>;
+  
+      beforeEach(() => {
+        mostroStore = useMostroStore()
+        mostroStore.addMostroInfo({
+          mostro_pubkey: 'my-mostro-pubkey',
+          created_at: 1739627993,
+          expiration_hours: 24,
+          expiration_seconds: 900,
+          fee: 0.01,
+          hold_invoice_expiration_window: 300,
+          invoice_expiration_window: 300,
+          max_order_amount: 1000000,
+          min_order_amount: 100,
+          mostro_commit_id: 'my-mostro-commit-id',
+          mostro_version: '0.13.0'
+        });
+        mostroStore.addMostroInfo({
+          mostro_pubkey: 'another-mostro-pubkey',
+          created_at: 1739627994,
+          expiration_hours: 48,
+          expiration_seconds: 1000,
+          fee: 0.05,
+          hold_invoice_expiration_window: 500,
+          invoice_expiration_window: 500,
+          max_order_amount: 5000000,
+          min_order_amount: 500,
+          mostro_commit_id: 'another-mostro-commit-id',
+          mostro_version: '0.12.0'
+        });
+      });
+      it ('returns info of first key', () => {
+        expect(mostroStore.getDefaultMostroInfo()).toEqual({
+          mostro_pubkey: 'my-mostro-pubkey',
+          created_at: 1739627993,
+          expiration_hours: 24,
+          expiration_seconds: 900,
+          fee: 0.01,
+          hold_invoice_expiration_window: 300,
+          invoice_expiration_window: 300,
+          max_order_amount: 1000000,
+          min_order_amount: 100,
+          mostro_commit_id: 'my-mostro-commit-id',
+          mostro_version: '0.13.0'
+        });
+      });
+    });
+  });
+
   describe('listMostroKeys', () => {
     describe('without mostro info', () => {
       it('listMostroKeys returns empty array', () => {
@@ -227,7 +331,7 @@ describe('useMostroStore', () => {
           max_order_amount: 5000000,
           min_order_amount: 500,
           mostro_commit_id: 'another-mostro-commit-id',
-          mostro_version: '0.12qq.0'
+          mostro_version: '0.12.0'
         });
       });  
       it('listMostroKeys returns all mostro keys', () => {


### PR DESCRIPTION
## Context
In the settings page, when clicking to show the secret, nothing was shown. If you ckicked the copy button, nothing was copied to the clipboard. As you can see in the screenshot there's a copy button and a hide button but there is no secret:
<img width="1512" alt="hide-nothing" src="https://github.com/user-attachments/assets/83f83dbd-97e6-49b6-b204-96dc2b96c35a" />

This is because the auth store now stores the secret as a mnemonic and the privKey of the auth store no longer exists

## What has been done
The mnemonic is now shown in the secret section, as you can see in the screenshot (the mnemonic shown was auto generated  for testing purposes, it's not mine or sensible in this case). The copy button now copies the mnemonic too. 


<img width="1506" alt="show-mnemonic" src="https://github.com/user-attachments/assets/ec5e8b3b-010f-4c38-9354-c5c23d1d0193" />

## What to check
- If it makes sense to replace the secret private key with the mnemonic
- If you  think that maybe the texts should also change 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Enhanced key and secret information display on the settings page for a more streamlined and robust user experience with improved fallback support.
- **Tests**
  - Added automated tests to validate the default key selection and secret handling, ensuring reliable behavior in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->